### PR TITLE
Items payload support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     minecraft: 976
   ```
 - Improve integration with Heroes class system (#14)
+- Add statistics about used items registries
 
 ### Housekeeping
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   ```
 - Improve integration with Heroes class system (#14)
 - Add statistics about used items registries
+- Add payload support to `MinecraftItemsRegistry`.
 
 ### Housekeeping
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     println("At least Mimic 0.6 is required. Please download it from {link here}")
   }
   ```
+- Add optional payload to `ItemsRegistry.getItem`. It may be used to customize item.
 
 ### Bukkit Plugin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   ```kotlin
   // Specify here the version required for APIs you use.
   if (!MimicApiLevel.checkApiLevel(MimicApiLevel.VERSION_0_6)) {
-    println("At least Mimic 0.6 is required. Please download it from {link here}")
+      println("At least Mimic 0.6 is required. Please download it from {link here}")
   }
   ```
 - Add optional payload to `ItemsRegistry.getItem`. It may be used to customize item.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+### API
+
+- Add `MimicApiLevel` class to check current running Mimic API version:
+  ```kotlin
+  // Specify here the version required for APIs you use.
+  if (!MimicApiLevel.checkApiLevel(MimicApiLevel.VERSION_0_6)) {
+    println("At least Mimic 0.6 is required. Please download it from {link here}")
+  }
+  ```
+
 ### Bukkit Plugin
 
 - More detailed output of command `/mimic items info`:

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,7 +8,9 @@ java {
 }
 
 dependencies {
-    implementation(kotlin("gradle-plugin", version = "1.5.21"))
+    val kotlinVersion = "1.5.21"
+    implementation(kotlin("gradle-plugin", version = kotlinVersion))
+    implementation(kotlin("serialization", version = kotlinVersion))
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.5.0")
     implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.6.0")
     implementation("de.undercouch:gradle-download-task:4.1.2")

--- a/buildSrc/src/main/kotlin/HoconSerializationRule.kt
+++ b/buildSrc/src/main/kotlin/HoconSerializationRule.kt
@@ -1,0 +1,15 @@
+import org.gradle.api.artifacts.CacheableRule
+import org.gradle.api.artifacts.ComponentMetadataContext
+import org.gradle.api.artifacts.ComponentMetadataRule
+import org.gradle.api.attributes.java.TargetJvmVersion
+
+@CacheableRule
+abstract class HoconSerializationRule : ComponentMetadataRule {
+    override fun execute(context: ComponentMetadataContext) {
+        context.details.allVariants {
+            attributes {
+                attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -33,6 +33,7 @@ object acf {
 
 object misc {
     const val bstats = "org.bstats:bstats-bukkit:1.8"
+    const val serialization_hocon = "org.jetbrains.kotlinx:kotlinx-serialization-hocon:1.2.2"
 }
 
 // Testing

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -33,6 +33,7 @@ object acf {
 
 object misc {
     const val bstats = "org.bstats:bstats-bukkit:1.8"
+    const val annotations = "org.jetbrains:annotations:13.0"
     const val serialization_hocon = "org.jetbrains.kotlinx:kotlinx-serialization-hocon:1.2.2"
 }
 

--- a/mimic-api/api/mimic-api.api
+++ b/mimic-api/api/mimic-api.api
@@ -25,7 +25,9 @@ public abstract interface class ru/endlesscode/mimic/classes/ClassSystem {
 
 public abstract interface class ru/endlesscode/mimic/items/ItemsRegistry : ru/endlesscode/mimic/MimicService {
 	public fun getItem (Ljava/lang/String;)Ljava/lang/Object;
-	public abstract fun getItem (Ljava/lang/String;I)Ljava/lang/Object;
+	public fun getItem (Ljava/lang/String;I)Ljava/lang/Object;
+	public fun getItem (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getItem (Ljava/lang/String;Ljava/lang/Object;I)Ljava/lang/Object;
 	public abstract fun getItemId (Ljava/lang/Object;)Ljava/lang/String;
 	public abstract fun getKnownIds ()Ljava/util/Collection;
 	public abstract fun isItemExists (Ljava/lang/String;)Z

--- a/mimic-api/api/mimic-api.api
+++ b/mimic-api/api/mimic-api.api
@@ -1,3 +1,10 @@
+public final class ru/endlesscode/mimic/MimicApiLevel {
+	public static final field CURRENT I
+	public static final field INSTANCE Lru/endlesscode/mimic/MimicApiLevel;
+	public static final field VERSION_0_6 I
+	public static final fun checkApiLevel (I)Z
+}
+
 public abstract interface class ru/endlesscode/mimic/MimicService {
 	public abstract fun getId ()Ljava/lang/String;
 	public abstract fun isEnabled ()Z

--- a/mimic-api/src/main/kotlin/MimicApiLevel.kt
+++ b/mimic-api/src/main/kotlin/MimicApiLevel.kt
@@ -23,7 +23,9 @@ package ru.endlesscode.mimic
 public object MimicApiLevel {
 
     /**
-     * Version 0.6
+     * # Version 0.6
+     * - Mimic API levels
+     * - Payload in ItemsRegistry.getItem
      */
     public const val VERSION_0_6: Int = 1
 

--- a/mimic-api/src/main/kotlin/MimicApiLevel.kt
+++ b/mimic-api/src/main/kotlin/MimicApiLevel.kt
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Mimic.
+ * Copyright (C) 2021 Osip Fatkullin
+ * Copyright (C) 2021 EndlessCode Group and contributors
+ *
+ * Mimic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Mimic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Mimic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ru.endlesscode.mimic
+
+/** Utility to check Mimic API level. */
+public object MimicApiLevel {
+
+    /**
+     * Version 0.6
+     */
+    public const val VERSION_0_6: Int = 1
+
+    /**
+     * The latest version at the moment of Mimic COMPILATION.
+     *
+     * Usage of this constant will be inlined by the compiler, so use it only to save the version
+     * which was used at your plugin COMPILE TIME.
+     * Use [checkApiLevel] if you want to check that the current RUNNING Mimic API level meets to
+     * the required.
+     */
+    public const val CURRENT: Int = VERSION_0_6
+
+    /**
+     * Returns 'true' if the current RUNNING Mimic API level meets to  the required, otherwise `false`.
+     * ```
+     * // Specify here the version required for APIs you use.
+     * if (!MimicApiLevel.checkApiLevel(MimicApiLevel.VERSION_0_6)) {
+     *     println("At least Mimic 0.6 is required. Please download it from {link here}")
+     * }
+     * ```
+     */
+    @JvmStatic
+    public fun checkApiLevel(apiLevel: Int): Boolean = CURRENT < apiLevel
+}

--- a/mimic-api/src/main/kotlin/items/ItemsRegistry.kt
+++ b/mimic-api/src/main/kotlin/items/ItemsRegistry.kt
@@ -21,7 +21,7 @@ package ru.endlesscode.mimic.items
 
 import ru.endlesscode.mimic.MimicService
 
-/** Service for getting items by theirs ID. Also can be used to match ID with item. */
+/** Service for getting items by theirs ID. Also, can be used to match ID with item. */
 public interface ItemsRegistry<ItemStackT : Any> : MimicService {
 
     /** Returns all known item IDs. */
@@ -37,7 +37,14 @@ public interface ItemsRegistry<ItemStackT : Any> : MimicService {
     public fun getItemId(item: ItemStackT): String?
 
     /** Returns item by given [itemId], or `null` if the ID not found in this registry. */
-    public fun getItem(itemId: String): ItemStackT? = getItem(itemId, amount = 1)
+    public fun getItem(itemId: String): ItemStackT? = getItem(itemId, payload = null, amount = 1)
+
+    /**
+     * Returns item stack with specified [payload] by given [itemId], or `null` if the ID not found in this registry.
+     *
+     * If [payload] is not `null`, item will be configured using it.
+     */
+    public fun getItem(itemId: String, payload: Any?): ItemStackT? = getItem(itemId, payload, amount = 1)
 
     /**
      * Returns item stack with specified [amount] by given [itemId], or `null` if ID not found in this registry.
@@ -45,5 +52,16 @@ public interface ItemsRegistry<ItemStackT : Any> : MimicService {
      * If given [amount] is greater than maximum possible, will use maximum possible amount.
      * Amount shouldn't be less than `1`.
      */
-    public fun getItem(itemId: String, amount: Int): ItemStackT?
+    public fun getItem(itemId: String, amount: Int): ItemStackT? = getItem(itemId, payload = null, amount)
+
+    /**
+     * Returns item stack with specified [amount] and [payload] by given [itemId],
+     * or `null` if ID not found in this registry.
+     *
+     * If given [amount] is greater than maximum possible, will use maximum possible amount.
+     * Amount shouldn't be less than `1`.
+     *
+     * Given [payload] may be used to configure item.
+     */
+    public fun getItem(itemId: String, payload: Any?, amount: Int): ItemStackT?
 }

--- a/mimic-bukkit-api/README.md
+++ b/mimic-bukkit-api/README.md
@@ -13,10 +13,21 @@ Available services:
 
 ### How to use Mimic APIs?
 
-Firstly you should make sure Mimic is enabled with such method:
+Firstly you should make sure Mimic is enabled:
 ```java
 private boolean checkMimicEnabled() {
-    return getServer().getPluginManager().isPluginEnabled("Mimic");
+    if (!getServer().getPluginManager().isPluginEnabled("Mimic")) {
+        getLogger().severe("Mimic is required for the plugin!");
+        return false;
+    }
+
+    // You can also check if Mimic version is right
+    if (!MimicApiLevel.checkApiLevel(MimicApiLevel.VERSION_0_6)) {
+        getLogger().severe("Required at least Mimic 0.6!");
+        return false;
+    }
+
+    return true;
 }
 ```
 
@@ -26,8 +37,7 @@ Another way is to add it to `softdepend` and show a clear error message to the s
 @Override
 public void onEnable() {
     if (!checkMimicEnabled()) {
-        getLogger().severe("Mimic is required for the plugin!");
-        getLogger().severe("Download it: https://www.spigotmc.org/resources/82515/");
+        getLogger().severe("Download latest version here: https://www.spigotmc.org/resources/82515/");
         getServer().getPluginManager().disablePlugin(this);
         return;
     }
@@ -99,17 +109,27 @@ boolean isMagicStickExists = itemsRegistry.isItemExists("customitems:magic_wand"
         @Override
         public void onEnable() {
             if (!checkMimicEnabled()) {
-                getLogger().severe("Mimic is required for the plugin!");
-                getLogger().severe("Download it on https://www.spigotmc.org/resources/82515/");
+                getLogger().severe("Download latest version here: https://www.spigotmc.org/resources/82515/");
                 getServer().getPluginManager().disablePlugin(this);
                 return;
             }
     
             setupMimic();
         }
-    
+
         private boolean checkMimicEnabled() {
-            return getServer().getPluginManager().isPluginEnabled("Mimic");
+            if (!getServer().getPluginManager().isPluginEnabled("Mimic")) {
+                getLogger().severe("Mimic is required for the plugin!");
+                return false;
+            }
+
+            // You can also check if Mimic version is right
+            if (!MimicApiLevel.checkApiLevel(MimicApiLevel.VERSION_0_6)) {
+                getLogger().severe("Required at least Mimic 0.6!");
+                return false;
+            }
+
+            return true;
         }
     
         private void setupMimic() {

--- a/mimic-bukkit/README.md
+++ b/mimic-bukkit/README.md
@@ -32,7 +32,7 @@ No configuration needed.
 
 You can find code of all implementations [here](src/main/kotlin/impl).
 
-#### [Level Systems][BukkitLevelSystem.Provider]
+### [Level Systems][BukkitLevelSystem.Provider]
 
 - **[Minecraft][minecraft-exp]** _(Default)_
 - **[SkillAPI]**
@@ -41,7 +41,7 @@ You can find code of all implementations [here](src/main/kotlin/impl).
 - **[Heroes]**
 - **[QuantumRPG]**
 
-#### [Class Systems][BukkitClassSystem.Provider]
+### [Class Systems][BukkitClassSystem.Provider]
 
 - **Permissions-based** _(Default)_ - give permission `mimic.class.[class_name]` to assign class to player
 - **[SkillAPI]**
@@ -49,19 +49,35 @@ You can find code of all implementations [here](src/main/kotlin/impl).
 - **[Heroes]**
 - **[QuantumRPG]**
 
-#### [Items Registries][BukkitItemsRegistry]
+### [Items Registries][BukkitItemsRegistry]
 
-[MimicItemsRegistry] - Items registry combining all others items registries.
-It uses service ID as namespace for items IDs.  
-For example: `acacia_boat -> minecraft:acacia_boat`.  
-If you use item ID without a namespace, it will search over all registries.
+#### [MimicItemsRegistry] 
 
- Registry                            | ID Structure      
--------------------------------------|--------------------------
- [Minecraft][MinecraftItemsRegistry] | `minecraft:[id]`
- [CustomItems]                       | `customitems:[id]`
- [MMOItems]                          | `mmoitems:[id]`
- [QuantumRPG]                        | `quantumrpg:[type]/[id]`
+Items registry combining all others items registries.
+It uses service ID as namespace for items IDs.\
+For example: `acacia_boat -> minecraft:acacia_boat`.
+
+> If you use item ID without a namespace, it will search over all registries.
+
+#### [Minecraft][MinecraftItemsRegistry]
+
+**ID Format:** `minecraft:[id]`\
+**Payload:** [ItemMetaPayload]
+
+#### [CustomItems]
+
+**ID Format:** `customitems:[id]`\
+**Payload:** *Not supported*
+
+#### [MMOItems]
+
+**ID Format:** `mmoitems:[id]`\
+**Payload:** *Not supported*
+
+#### [QuantumRPG]
+
+**ID Format:** `quantumrpg:[type]/[id]`\
+**Payload:** *Not supported*
 
 [minecraft-exp]: https://minecraft.gamepedia.com/Experience
 [skillapi]: https://www.spigotmc.org/resources/4824/
@@ -79,3 +95,4 @@ If you use item ID without a namespace, it will search over all registries.
 [BukkitItemsRegistry]: ../mimic-bukkit-api/src/main/kotlin/items/BukkitItemsRegistry.kt
 [MimicItemsRegistry]: src/main/kotlin/impl/mimic/MimicItemsRegistry.kt
 [MinecraftItemsRegistry]: src/main/kotlin/impl/vanilla/MinecraftItemsRegistry.kt
+[ItemMetaPayload]: src/main/kotlin/impl/vanilla/ItemMetaPayload.kt

--- a/mimic-bukkit/api/mimic-bukkit.api
+++ b/mimic-bukkit/api/mimic-bukkit.api
@@ -275,6 +275,52 @@ public final class ru/endlesscode/mimic/impl/skillapi/SkillApiLevelSystem : ru/e
 public final class ru/endlesscode/mimic/impl/skillapi/SkillApiLevelSystem$Companion {
 }
 
+public final class ru/endlesscode/mimic/impl/vanilla/ItemMetaPayload {
+	public static final field Companion Lru/endlesscode/mimic/impl/vanilla/ItemMetaPayload$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/List;ZILjava/lang/Integer;Ljava/util/Map;Ljava/util/Set;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;ZILjava/lang/Integer;Ljava/util/Map;Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ZILjava/lang/Integer;Ljava/util/Map;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Z
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun component7 ()Ljava/util/Set;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;ZILjava/lang/Integer;Ljava/util/Map;Ljava/util/Set;)Lru/endlesscode/mimic/impl/vanilla/ItemMetaPayload;
+	public static synthetic fun copy$default (Lru/endlesscode/mimic/impl/vanilla/ItemMetaPayload;Ljava/lang/String;Ljava/util/List;ZILjava/lang/Integer;Ljava/util/Map;Ljava/util/Set;ILjava/lang/Object;)Lru/endlesscode/mimic/impl/vanilla/ItemMetaPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustomModelData ()Ljava/lang/Integer;
+	public final fun getDamage ()I
+	public final fun getEnchantments ()Ljava/util/Map;
+	public final fun getFlags ()Ljava/util/Set;
+	public final fun getLore ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isUnbreakable ()Z
+	public static final fun parse (Ljava/lang/String;)Lru/endlesscode/mimic/impl/vanilla/ItemMetaPayload;
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lru/endlesscode/mimic/impl/vanilla/ItemMetaPayload;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class ru/endlesscode/mimic/impl/vanilla/ItemMetaPayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lru/endlesscode/mimic/impl/vanilla/ItemMetaPayload$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lru/endlesscode/mimic/impl/vanilla/ItemMetaPayload;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lru/endlesscode/mimic/impl/vanilla/ItemMetaPayload;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ru/endlesscode/mimic/impl/vanilla/ItemMetaPayload$Companion {
+	public final fun parse (Ljava/lang/String;)Lru/endlesscode/mimic/impl/vanilla/ItemMetaPayload;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class ru/endlesscode/mimic/impl/vanilla/MinecraftExpLevelConverter : ru/endlesscode/mimic/level/ExpLevelConverter {
 	public static final field Companion Lru/endlesscode/mimic/impl/vanilla/MinecraftExpLevelConverter$Companion;
 	public fun expToLevel (D)D

--- a/mimic-bukkit/api/mimic-bukkit.api
+++ b/mimic-bukkit/api/mimic-bukkit.api
@@ -299,6 +299,7 @@ public final class ru/endlesscode/mimic/impl/vanilla/ItemMetaPayload {
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun isUnbreakable ()Z
+	public static final fun of (Ljava/lang/Object;)Lru/endlesscode/mimic/impl/vanilla/ItemMetaPayload;
 	public static final fun parse (Ljava/lang/String;)Lru/endlesscode/mimic/impl/vanilla/ItemMetaPayload;
 	public fun toString ()Ljava/lang/String;
 	public static final fun write$Self (Lru/endlesscode/mimic/impl/vanilla/ItemMetaPayload;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -317,6 +318,7 @@ public final class ru/endlesscode/mimic/impl/vanilla/ItemMetaPayload$$serializer
 }
 
 public final class ru/endlesscode/mimic/impl/vanilla/ItemMetaPayload$Companion {
+	public final fun of (Ljava/lang/Object;)Lru/endlesscode/mimic/impl/vanilla/ItemMetaPayload;
 	public final fun parse (Ljava/lang/String;)Lru/endlesscode/mimic/impl/vanilla/ItemMetaPayload;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }

--- a/mimic-bukkit/api/mimic-bukkit.api
+++ b/mimic-bukkit/api/mimic-bukkit.api
@@ -45,8 +45,8 @@ public final class ru/endlesscode/mimic/impl/customitems/CustomItemsRegistry : r
 	public static final field ID Ljava/lang/String;
 	public fun <init> ()V
 	public fun getId ()Ljava/lang/String;
-	public synthetic fun getItem (Ljava/lang/String;I)Ljava/lang/Object;
-	public fun getItem (Ljava/lang/String;I)Lorg/bukkit/inventory/ItemStack;
+	public synthetic fun getItem (Ljava/lang/String;Ljava/lang/Object;I)Ljava/lang/Object;
+	public fun getItem (Ljava/lang/String;Ljava/lang/Object;I)Lorg/bukkit/inventory/ItemStack;
 	public synthetic fun getItemId (Ljava/lang/Object;)Ljava/lang/String;
 	public fun getItemId (Lorg/bukkit/inventory/ItemStack;)Ljava/lang/String;
 	public fun getKnownIds ()Ljava/util/Collection;
@@ -100,8 +100,8 @@ public final class ru/endlesscode/mimic/impl/mimic/MimicItemsRegistry : ru/endle
 	public static final field ID Ljava/lang/String;
 	public fun <init> (Lorg/bukkit/plugin/ServicesManager;)V
 	public fun getId ()Ljava/lang/String;
-	public synthetic fun getItem (Ljava/lang/String;I)Ljava/lang/Object;
-	public fun getItem (Ljava/lang/String;I)Lorg/bukkit/inventory/ItemStack;
+	public synthetic fun getItem (Ljava/lang/String;Ljava/lang/Object;I)Ljava/lang/Object;
+	public fun getItem (Ljava/lang/String;Ljava/lang/Object;I)Lorg/bukkit/inventory/ItemStack;
 	public synthetic fun getItemId (Ljava/lang/Object;)Ljava/lang/String;
 	public fun getItemId (Lorg/bukkit/inventory/ItemStack;)Ljava/lang/String;
 	public fun getKnownIds ()Ljava/util/Collection;
@@ -168,8 +168,8 @@ public final class ru/endlesscode/mimic/impl/mmoitems/MmoItemsRegistry : ru/endl
 	public static final field Companion Lru/endlesscode/mimic/impl/mmoitems/MmoItemsRegistry$Companion;
 	public static final field ID Ljava/lang/String;
 	public fun getId ()Ljava/lang/String;
-	public synthetic fun getItem (Ljava/lang/String;I)Ljava/lang/Object;
-	public fun getItem (Ljava/lang/String;I)Lorg/bukkit/inventory/ItemStack;
+	public synthetic fun getItem (Ljava/lang/String;Ljava/lang/Object;I)Ljava/lang/Object;
+	public fun getItem (Ljava/lang/String;Ljava/lang/Object;I)Lorg/bukkit/inventory/ItemStack;
 	public synthetic fun getItemId (Ljava/lang/Object;)Ljava/lang/String;
 	public fun getItemId (Lorg/bukkit/inventory/ItemStack;)Ljava/lang/String;
 	public fun getKnownIds ()Ljava/util/Collection;
@@ -205,8 +205,8 @@ public final class ru/endlesscode/mimic/impl/quantumrpg/QuantumRpgItemsRegistry 
 	public static final field Companion Lru/endlesscode/mimic/impl/quantumrpg/QuantumRpgItemsRegistry$Companion;
 	public static final field ID Ljava/lang/String;
 	public fun getId ()Ljava/lang/String;
-	public synthetic fun getItem (Ljava/lang/String;I)Ljava/lang/Object;
-	public fun getItem (Ljava/lang/String;I)Lorg/bukkit/inventory/ItemStack;
+	public synthetic fun getItem (Ljava/lang/String;Ljava/lang/Object;I)Ljava/lang/Object;
+	public fun getItem (Ljava/lang/String;Ljava/lang/Object;I)Lorg/bukkit/inventory/ItemStack;
 	public synthetic fun getItemId (Ljava/lang/Object;)Ljava/lang/String;
 	public fun getItemId (Lorg/bukkit/inventory/ItemStack;)Ljava/lang/String;
 	public fun getKnownIds ()Ljava/util/Collection;
@@ -293,8 +293,8 @@ public final class ru/endlesscode/mimic/impl/vanilla/MinecraftItemsRegistry : ru
 	public static final field ID Ljava/lang/String;
 	public fun <init> ()V
 	public fun getId ()Ljava/lang/String;
-	public synthetic fun getItem (Ljava/lang/String;I)Ljava/lang/Object;
-	public fun getItem (Ljava/lang/String;I)Lorg/bukkit/inventory/ItemStack;
+	public synthetic fun getItem (Ljava/lang/String;Ljava/lang/Object;I)Ljava/lang/Object;
+	public fun getItem (Ljava/lang/String;Ljava/lang/Object;I)Lorg/bukkit/inventory/ItemStack;
 	public synthetic fun getItemId (Ljava/lang/Object;)Ljava/lang/String;
 	public fun getItemId (Lorg/bukkit/inventory/ItemStack;)Ljava/lang/String;
 	public synthetic fun getKnownIds ()Ljava/util/Collection;

--- a/mimic-bukkit/build.gradle.kts
+++ b/mimic-bukkit/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import ru.endlesscode.bukkitgradle.dependencies.aikar
 import ru.endlesscode.bukkitgradle.dependencies.codemc
 import ru.endlesscode.bukkitgradle.dependencies.spigotApi
@@ -5,6 +6,7 @@ import ru.endlesscode.bukkitgradle.dependencies.spigotApi
 plugins {
     id("com.github.johnrengelman.shadow") version "7.0.0"
     id("ru.endlesscode.bukkitgradle") version "0.10.0"
+    kotlin("plugin.serialization")
 }
 
 description = "Bukkit plugin with implementations of Mimic APIs"
@@ -40,6 +42,7 @@ dependencies {
     compileOnly(spigotApi) { isTransitive = false }
     implementation(acf.paper)
     implementation(misc.bstats)
+    implementation(misc.serialization_hocon)
 
     compileOnly(rpgplugins.skillapi)
     compileOnly(rpgplugins.battlelevels)
@@ -56,6 +59,16 @@ dependencies {
 
     testImplementation(spigotApi)
     testImplementation(rpgplugins.skillapi)
+
+    // TODO: Remove after this bug will be fixed
+    //  Issue: https://github.com/Kotlin/kotlinx.serialization/issues/1189
+    components {
+        withModule<HoconSerializationRule>("org.jetbrains.kotlinx:kotlinx-serialization-hocon")
+    }
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlinx.serialization.ExperimentalSerializationApi"
 }
 
 tasks.shadowJar {
@@ -72,4 +85,3 @@ tasks.shadowJar {
 
     minimize()
 }
-

--- a/mimic-bukkit/build.gradle.kts
+++ b/mimic-bukkit/build.gradle.kts
@@ -40,6 +40,8 @@ dependencies {
     api(project(":mimic-bukkit-api"))
 
     compileOnly(spigotApi) { isTransitive = false }
+    compileOnly(misc.annotations)
+
     implementation(acf.paper)
     implementation(misc.bstats)
     implementation(misc.serialization_hocon)
@@ -72,13 +74,16 @@ tasks.withType<KotlinCompile>().configureEach {
 }
 
 tasks.shadowJar {
+    dependencies {
+        exclude(dependency(misc.annotations))
+    }
+
     val shadePackage = "${project.group}.shade"
     relocate("co.aikar.commands", "$shadePackage.acf.commands")
     relocate("co.aikar.locales", "$shadePackage.acf.locales")
     relocate("kotlin", "$shadePackage.kotlin")
-    relocate("org.intellij", "$shadePackage.intellij")
-    relocate("org.jetbrains", "$shadePackage.jetbrains")
     relocate("org.bstats.bukkit", "$shadePackage.bstats")
+    relocate("com.typesafe.config", "$shadePackage.hocon")
 
     exclude("META-INF/*.kotlin_module")
     exclude("META-INF/maven/**")

--- a/mimic-bukkit/src/main/kotlin/Mimic.kt
+++ b/mimic-bukkit/src/main/kotlin/Mimic.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of BukkitMimic.
- * Copyright (C) 2020 Osip Fatkullin
- * Copyright (C) 2020 EndlessCode Group and contributors
+ * Copyright (C) 2021 Osip Fatkullin
+ * Copyright (C) 2021 EndlessCode Group and contributors
  *
  * BukkitMimic is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,6 +25,7 @@ import org.bukkit.plugin.ServicePriority
 import org.bukkit.plugin.ServicePriority.*
 import org.bukkit.plugin.java.JavaPlugin
 import ru.endlesscode.mimic.bukkit.load
+import ru.endlesscode.mimic.bukkit.loadAll
 import ru.endlesscode.mimic.classes.BukkitClassSystem
 import ru.endlesscode.mimic.command.ClassSystemSubcommand
 import ru.endlesscode.mimic.command.ItemsSubcommand
@@ -147,6 +148,12 @@ public class Mimic : JavaPlugin() {
         })
         metrics.addCustomChart(Metrics.SimplePie("class_system") {
             loadService<BukkitClassSystem.Provider>().id
+        })
+        metrics.addCustomChart(Metrics.AdvancedPie("items_registry_custom") {
+            servicesManager.loadAll<BukkitItemsRegistry>()
+                .map { it.id }
+                .filterNot { it == MimicItemsRegistry.ID || it == MinecraftItemsRegistry.ID }
+                .associateWith { 1 }
         })
     }
 

--- a/mimic-bukkit/src/main/kotlin/command/ItemsSubcommand.kt
+++ b/mimic-bukkit/src/main/kotlin/command/ItemsSubcommand.kt
@@ -52,14 +52,15 @@ internal class ItemsSubcommand(private val itemsRegistry: BukkitItemsRegistry) :
 
     @Subcommand("give")
     @Description("Give item to player")
-    @CommandCompletion("@players @item")
+    @CommandCompletion("@players @item @nothing")
     fun give(
         sender: CommandSender,
         @Flags("other") player: Player,
         item: String,
-        @Default("1") amount: Int
+        @Default("1") amount: Int,
+        @Optional payload: String?,
     ) {
-        val itemStack = itemsRegistry.getItem(item, amount)
+        val itemStack = itemsRegistry.getItem(item, payload, amount)
         if (itemStack != null) {
             player.inventory.addItem(itemStack)
             sender.send("&6Gave ${itemStack.amount} [$item] to ${player.name}.")
@@ -73,7 +74,7 @@ internal class ItemsSubcommand(private val itemsRegistry: BukkitItemsRegistry) :
     @CommandCompletion("@item")
     fun compare(
         @Flags("itemheld") player: Player,
-        @Single item: String
+        @Single item: String,
     ) {
         val isSame = itemsRegistry.isSameItem(player.inventory.itemInMainHand, item)
         player.send("&6Item in hand and '$item' are%s same.".format(if (isSame) "" else "n't"))
@@ -82,7 +83,7 @@ internal class ItemsSubcommand(private val itemsRegistry: BukkitItemsRegistry) :
     @Subcommand("id")
     @Description("Prints ID of item in hand")
     fun id(
-        @Flags("itemheld") player: Player
+        @Flags("itemheld") player: Player,
     ) {
         val id = itemsRegistry.getItemId(player.inventory.itemInMainHand)
         player.send("&6Id of item in hand is '$id'")
@@ -93,7 +94,7 @@ internal class ItemsSubcommand(private val itemsRegistry: BukkitItemsRegistry) :
     @CommandCompletion("@item")
     fun find(
         sender: CommandSender,
-        @Single item: String
+        @Single item: String,
     ) {
         val itemExists = itemsRegistry.isItemExists(item)
         sender.send("&6Item with id '$item'%s exists".format(if (itemExists) "" else " isn't"))

--- a/mimic-bukkit/src/main/kotlin/impl/customitems/CustomItemsRegistry.kt
+++ b/mimic-bukkit/src/main/kotlin/impl/customitems/CustomItemsRegistry.kt
@@ -42,5 +42,5 @@ public class CustomItemsRegistry : BukkitItemsRegistry {
 
     override fun getItemId(item: ItemStack): String? = CustomItemsAPI.getCustomItemID(item)?.lowercase()
 
-    override fun getItem(itemId: String, amount: Int): ItemStack? = CustomItemsAPI.getCustomItem(itemId, amount)
+    override fun getItem(itemId: String, payload: Any?, amount: Int): ItemStack? = CustomItemsAPI.getCustomItem(itemId, amount)
 }

--- a/mimic-bukkit/src/main/kotlin/impl/mimic/MimicItemsRegistry.kt
+++ b/mimic-bukkit/src/main/kotlin/impl/mimic/MimicItemsRegistry.kt
@@ -67,9 +67,9 @@ public class MimicItemsRegistry(private val servicesManager: ServicesManager) : 
             .firstOrNull()
     }
 
-    override fun getItem(itemId: String, amount: Int): ItemStack? {
+    override fun getItem(itemId: String, payload: Any?, amount: Int): ItemStack? {
         return runOnServices(itemId) { id ->
-            mapNotNull { service -> service.getItem(id, amount) }
+            mapNotNull { service -> service.getItem(id, payload, amount) }
                 .firstOrNull()
         }
     }

--- a/mimic-bukkit/src/main/kotlin/impl/mmoitems/MmoItemsRegistry.kt
+++ b/mimic-bukkit/src/main/kotlin/impl/mmoitems/MmoItemsRegistry.kt
@@ -49,7 +49,7 @@ public class MmoItemsRegistry private constructor(private val mmoItems: MmoItems
         return nbtItem.getString("MMOITEMS_ITEM_ID")?.lowercase()
     }
 
-    override fun getItem(itemId: String, amount: Int): ItemStack? {
+    override fun getItem(itemId: String, payload: Any?, amount: Int): ItemStack? {
         val template = templates.find { it.id.equals(itemId, ignoreCase = true) } ?: return null
 
         return template.buildItemStack()

--- a/mimic-bukkit/src/main/kotlin/impl/quantumrpg/QuantumRpgItemsRegistry.kt
+++ b/mimic-bukkit/src/main/kotlin/impl/quantumrpg/QuantumRpgItemsRegistry.kt
@@ -1,3 +1,22 @@
+/*
+ * This file is part of BukkitMimic.
+ * Copyright (C) 2021 Osip Fatkullin
+ * Copyright (C) 2021 EndlessCode Group and contributors
+ *
+ * BukkitMimic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BukkitMimic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BukkitMimic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ru.endlesscode.mimic.impl.quantumrpg
 
 import org.bukkit.inventory.ItemStack
@@ -41,7 +60,7 @@ public class QuantumRpgItemsRegistry private constructor(
             .firstOrNull()
     }
 
-    override fun getItem(itemId: String, amount: Int): ItemStack? {
+    override fun getItem(itemId: String, payload: Any?, amount: Int): ItemStack? {
         return runOnModules(itemId) { id ->
             mapNotNull { module -> module.getItemById(id) }
                 .map { it.create() }

--- a/mimic-bukkit/src/main/kotlin/impl/vanilla/ItemMetaPayload.kt
+++ b/mimic-bukkit/src/main/kotlin/impl/vanilla/ItemMetaPayload.kt
@@ -1,0 +1,38 @@
+/*
+ * This file is part of BukkitMimic.
+ * Copyright (C) 2021 Osip Fatkullin
+ * Copyright (C) 2021 EndlessCode Group and contributors
+ *
+ * BukkitMimic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BukkitMimic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BukkitMimic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ru.endlesscode.mimic.impl.vanilla
+
+import org.bukkit.enchantments.Enchantment
+import org.bukkit.inventory.ItemFlag
+
+/**
+ * Payload to configure item's [ItemMeta][org.bukkit.inventory.meta.ItemMeta].
+ * @see org.bukkit.inventory.meta.ItemMeta
+ */
+public data class ItemMetaPayload(
+    val displayName: String? = null,
+    val localizedName: String? = null,
+    val lore: List<String>? = null,
+    val isUnbreakable: Boolean = false,
+    val damage: Int = 0,
+    val customModelData: Int? = null,
+    val enchants: Map<Enchantment, Int> = emptyMap(),
+    val itemFlags: List<ItemFlag> = emptyList(),
+)

--- a/mimic-bukkit/src/main/kotlin/impl/vanilla/ItemMetaPayload.kt
+++ b/mimic-bukkit/src/main/kotlin/impl/vanilla/ItemMetaPayload.kt
@@ -61,6 +61,20 @@ public data class ItemMetaPayload(
     public companion object {
 
         /**
+         * Returns [ItemMetaPayload] if it can be retrieved from the given [payload] value.
+         *
+         * Supported types are:
+         * - [ItemMetaPayload] - returns itself
+         * - [String] - tries to parse payload using [ItemMetaPayload.parse]
+         */
+        @JvmStatic
+        public fun of(payload: Any?): ItemMetaPayload? = when (payload) {
+            is ItemMetaPayload -> payload
+            is String -> parse(payload)
+            else -> null
+        }
+
+        /**
          * Tries to parse [ItemMetaPayload] from the given [input].
          * Returns `null` if parsing failed or [input] is empty.
          *

--- a/mimic-bukkit/src/main/kotlin/impl/vanilla/ItemMetaPayload.kt
+++ b/mimic-bukkit/src/main/kotlin/impl/vanilla/ItemMetaPayload.kt
@@ -35,6 +35,14 @@ import ru.endlesscode.mimic.internal.Log
 
 /**
  * Payload to configure item's [ItemMeta][org.bukkit.inventory.meta.ItemMeta].
+ *
+ * @property name Item name. You can specify colors using symbol `&`.
+ * @property lore Item lore. You can specify colors using symbol `&`.
+ * @property isUnbreakable Is item unbreakable. Affects only items that have durability (like weapons or tools).
+ * @property damage Damage to item durability. Affects only items that have durability (like weapons or tools).
+ * @property customModelData A value used to override item model.
+ * @property enchantments Item's enchantments. See [Enchantment].
+ * @property flags Item flags used to hide information about item from lore. See [ItemFlag].
  * @see org.bukkit.inventory.meta.ItemMeta
  * @see ItemMetaPayload.parse
  */
@@ -58,6 +66,17 @@ public data class ItemMetaPayload(
          *
          * Input should be formatted in [HOCON](https://github.com/lightbend/config/blob/main/HOCON.md).
          * Unknown fields are ignored.
+         * ```
+         * {
+         *   name = "&6Item Name"
+         *   lore = [Line1, Line2]
+         *   unbreakable = true
+         *   damage = 42
+         *   custom-model-data = 1
+         *   flags = [hide_attributes, hide_dye]
+         *   enchantments = {unbreaking: 3}
+         * }
+         * ```
          */
         @JvmStatic
         public fun parse(input: String): ItemMetaPayload? {

--- a/mimic-bukkit/src/main/kotlin/impl/vanilla/ItemMetaPayload.kt
+++ b/mimic-bukkit/src/main/kotlin/impl/vanilla/ItemMetaPayload.kt
@@ -17,15 +17,24 @@
  * along with BukkitMimic.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+@file:UseSerializers(EnchantmentSerializer::class)
+
 package ru.endlesscode.mimic.impl.vanilla
 
+import com.typesafe.config.ConfigFactory
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import kotlinx.serialization.hocon.decodeFromConfig
 import org.bukkit.enchantments.Enchantment
 import org.bukkit.inventory.ItemFlag
+import ru.endlesscode.mimic.internal.DI
+import ru.endlesscode.mimic.internal.EnchantmentSerializer
 
 /**
  * Payload to configure item's [ItemMeta][org.bukkit.inventory.meta.ItemMeta].
  * @see org.bukkit.inventory.meta.ItemMeta
  */
+@Serializable
 public data class ItemMetaPayload(
     val displayName: String? = null,
     val localizedName: String? = null,
@@ -35,4 +44,21 @@ public data class ItemMetaPayload(
     val customModelData: Int? = null,
     val enchants: Map<Enchantment, Int> = emptyMap(),
     val itemFlags: List<ItemFlag> = emptyList(),
-)
+) {
+
+    public companion object {
+
+        /**
+         * Tries to parse [ItemMetaPayload] from the given [input].
+         * Returns `null` if parsing failed or [input] is empty.
+         *
+         * Input should be formatted in [HOCON](https://github.com/lightbend/config/blob/main/HOCON.md).
+         * Unknown fields are ignored.
+         */
+        @JvmStatic
+        public fun parse(input: String): ItemMetaPayload? {
+            val hocon = DI.hocon
+            return hocon.decodeFromConfig(ConfigFactory.parseString(input))
+        }
+    }
+}

--- a/mimic-bukkit/src/main/kotlin/impl/vanilla/ItemMetaPayload.kt
+++ b/mimic-bukkit/src/main/kotlin/impl/vanilla/ItemMetaPayload.kt
@@ -22,6 +22,7 @@
 package ru.endlesscode.mimic.impl.vanilla
 
 import com.typesafe.config.ConfigFactory
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.hocon.decodeFromConfig
@@ -35,17 +36,18 @@ import ru.endlesscode.mimic.internal.Log
 /**
  * Payload to configure item's [ItemMeta][org.bukkit.inventory.meta.ItemMeta].
  * @see org.bukkit.inventory.meta.ItemMeta
+ * @see ItemMetaPayload.parse
  */
 @Serializable
 public data class ItemMetaPayload(
-    val displayName: String? = null,
-    val localizedName: String? = null,
+    val name: String? = null,
     val lore: List<String>? = null,
+    @SerialName("unbreakable")
     val isUnbreakable: Boolean = false,
     val damage: Int = 0,
     val customModelData: Int? = null,
-    val enchants: Map<Enchantment, Int> = emptyMap(),
-    val itemFlags: Set<ItemFlag> = emptySet(),
+    val enchantments: Map<Enchantment, Int> = emptyMap(),
+    val flags: Set<ItemFlag> = emptySet(),
 ) {
 
     public companion object {

--- a/mimic-bukkit/src/main/kotlin/impl/vanilla/ItemMetaPayload.kt
+++ b/mimic-bukkit/src/main/kotlin/impl/vanilla/ItemMetaPayload.kt
@@ -17,7 +17,7 @@
  * along with BukkitMimic.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-@file:UseSerializers(EnchantmentSerializer::class)
+@file:UseSerializers(EnchantmentSerializer::class, ItemFlagsSerializer::class)
 
 package ru.endlesscode.mimic.impl.vanilla
 
@@ -29,6 +29,7 @@ import org.bukkit.enchantments.Enchantment
 import org.bukkit.inventory.ItemFlag
 import ru.endlesscode.mimic.internal.DI
 import ru.endlesscode.mimic.internal.EnchantmentSerializer
+import ru.endlesscode.mimic.internal.ItemFlagsSerializer
 
 /**
  * Payload to configure item's [ItemMeta][org.bukkit.inventory.meta.ItemMeta].
@@ -43,7 +44,7 @@ public data class ItemMetaPayload(
     val damage: Int = 0,
     val customModelData: Int? = null,
     val enchants: Map<Enchantment, Int> = emptyMap(),
-    val itemFlags: List<ItemFlag> = emptyList(),
+    val itemFlags: Set<ItemFlag> = emptySet(),
 ) {
 
     public companion object {

--- a/mimic-bukkit/src/main/kotlin/impl/vanilla/ItemMetaPayload.kt
+++ b/mimic-bukkit/src/main/kotlin/impl/vanilla/ItemMetaPayload.kt
@@ -30,6 +30,7 @@ import org.bukkit.inventory.ItemFlag
 import ru.endlesscode.mimic.internal.DI
 import ru.endlesscode.mimic.internal.EnchantmentSerializer
 import ru.endlesscode.mimic.internal.ItemFlagsSerializer
+import ru.endlesscode.mimic.internal.Log
 
 /**
  * Payload to configure item's [ItemMeta][org.bukkit.inventory.meta.ItemMeta].
@@ -58,8 +59,12 @@ public data class ItemMetaPayload(
          */
         @JvmStatic
         public fun parse(input: String): ItemMetaPayload? {
-            val hocon = DI.hocon
-            return hocon.decodeFromConfig(ConfigFactory.parseString(input))
+            return try {
+                DI.hocon.decodeFromConfig(ConfigFactory.parseString(input))
+            } catch (e: Exception) {
+                Log.w(e)
+                null
+            }
         }
     }
 }

--- a/mimic-bukkit/src/main/kotlin/impl/vanilla/MinecraftItemsRegistry.kt
+++ b/mimic-bukkit/src/main/kotlin/impl/vanilla/MinecraftItemsRegistry.kt
@@ -24,6 +24,7 @@ import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.Damageable
 import org.bukkit.inventory.meta.ItemMeta
 import ru.endlesscode.mimic.internal.Log
+import ru.endlesscode.mimic.internal.colorized
 import ru.endlesscode.mimic.items.BukkitItemsRegistry
 
 /** Items service implementation using material name as itemId. */
@@ -53,7 +54,7 @@ public class MinecraftItemsRegistry : BukkitItemsRegistry {
 
         val minecraftPayload: ItemMetaPayload? = when (payload) {
             is ItemMetaPayload -> payload
-            is String -> parsePayload(payload)
+            is String -> ItemMetaPayload.parse(payload)
             null -> null
             else -> unknownPayload(itemId, payload)
         }
@@ -68,10 +69,6 @@ public class MinecraftItemsRegistry : BukkitItemsRegistry {
             ?.takeIf { it.isItem }
     }
 
-    private fun parsePayload(payload: String): ItemMetaPayload {
-        TODO("Not yet implemented")
-    }
-
     private fun unknownPayload(itemId: String, payload: Any): ItemMetaPayload? {
         Log.w("[${javaClass.simpleName}] Ignoring unsupported payload for item $itemId:\n$payload")
         return null
@@ -81,9 +78,9 @@ public class MinecraftItemsRegistry : BukkitItemsRegistry {
         if (payload == null) return this
 
         // Apply text options
-        setDisplayName(payload.displayName)
-        setLocalizedName(payload.localizedName)
-        lore = payload.lore
+        setDisplayName(payload.displayName?.colorized())
+        setLocalizedName(payload.localizedName?.colorized())
+        lore = payload.lore?.colorized()
 
         // Apply damage or custom model data
         isUnbreakable = payload.isUnbreakable

--- a/mimic-bukkit/src/main/kotlin/impl/vanilla/MinecraftItemsRegistry.kt
+++ b/mimic-bukkit/src/main/kotlin/impl/vanilla/MinecraftItemsRegistry.kt
@@ -44,7 +44,7 @@ public class MinecraftItemsRegistry : BukkitItemsRegistry {
 
     override fun getItemId(item: ItemStack): String = item.type.name.lowercase()
 
-    override fun getItem(itemId: String, amount: Int): ItemStack? {
+    override fun getItem(itemId: String, payload: Any?, amount: Int): ItemStack? {
         val material = getMaterial(itemId) ?: return null
         val realAmount = amount.coerceIn(1, material.maxStackSize)
         return ItemStack(material, realAmount)

--- a/mimic-bukkit/src/main/kotlin/impl/vanilla/MinecraftItemsRegistry.kt
+++ b/mimic-bukkit/src/main/kotlin/impl/vanilla/MinecraftItemsRegistry.kt
@@ -27,7 +27,10 @@ import ru.endlesscode.mimic.internal.Log
 import ru.endlesscode.mimic.internal.colorized
 import ru.endlesscode.mimic.items.BukkitItemsRegistry
 
-/** Items service implementation using material name as itemId. */
+/**
+ * Items service implementation using material name as itemId.
+ * Supports [ItemMetaPayload] as a payload in [getItem].
+ */
 public class MinecraftItemsRegistry : BukkitItemsRegistry {
 
     public companion object {
@@ -78,18 +81,17 @@ public class MinecraftItemsRegistry : BukkitItemsRegistry {
         if (payload == null) return this
 
         // Apply text options
-        setDisplayName(payload.displayName?.colorized())
-        setLocalizedName(payload.localizedName?.colorized())
+        setDisplayName(payload.name?.colorized())
         lore = payload.lore?.colorized()
 
-        // Apply damage or custom model data
+        // Apply damage and custom model data
         isUnbreakable = payload.isUnbreakable
         (this as? Damageable)?.damage = payload.damage
         setCustomModelData(payload.customModelData)
 
         // Apply enchants and item flags
-        payload.enchants.forEach { (enchant, level) -> addEnchant(enchant, level, true) }
-        addItemFlags(*payload.itemFlags.toTypedArray())
+        payload.enchantments.forEach { (enchant, level) -> addEnchant(enchant, level, true) }
+        addItemFlags(*payload.flags.toTypedArray())
 
         return this
     }

--- a/mimic-bukkit/src/main/kotlin/internal/Colors.kt
+++ b/mimic-bukkit/src/main/kotlin/internal/Colors.kt
@@ -1,7 +1,28 @@
+/*
+ * This file is part of BukkitMimic.
+ * Copyright (C) 2021 Osip Fatkullin
+ * Copyright (C) 2021 EndlessCode Group and contributors
+ *
+ * BukkitMimic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BukkitMimic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BukkitMimic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package ru.endlesscode.mimic.internal
 
 import org.bukkit.ChatColor
 
-internal fun String.stripColor(): String {
-    return checkNotNull(ChatColor.stripColor(this))
-}
+internal fun List<String>.colorized(): List<String> = map { it.colorized() }
+
+internal fun String.colorized(): String = ChatColor.translateAlternateColorCodes('&', this)
+
+internal fun String.stripColor(): String = checkNotNull(ChatColor.stripColor(this))

--- a/mimic-bukkit/src/main/kotlin/internal/DI.kt
+++ b/mimic-bukkit/src/main/kotlin/internal/DI.kt
@@ -1,0 +1,32 @@
+/*
+ * This file is part of BukkitMimic.
+ * Copyright (C) 2021 Osip Fatkullin
+ * Copyright (C) 2021 EndlessCode Group and contributors
+ *
+ * BukkitMimic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BukkitMimic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BukkitMimic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ru.endlesscode.mimic.internal
+
+import kotlinx.serialization.hocon.Hocon
+
+/** Dependencies available for the whole plugin. */
+internal object DI {
+
+    val hocon: Hocon by lazy {
+        Hocon {
+            useConfigNamingConvention = true
+        }
+    }
+}

--- a/mimic-bukkit/src/main/kotlin/internal/Enum.kt
+++ b/mimic-bukkit/src/main/kotlin/internal/Enum.kt
@@ -1,0 +1,29 @@
+/*
+ * This file is part of BukkitMimic.
+ * Copyright (C) 2021 Osip Fatkullin
+ * Copyright (C) 2021 EndlessCode Group and contributors
+ *
+ * BukkitMimic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BukkitMimic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BukkitMimic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ru.endlesscode.mimic.internal
+
+/** Returns enum of type [T] associated with given [name], or returns `null`. */
+internal inline fun <reified T : Enum<T>> enumValueOrNull(name: String): T? {
+    return try {
+        enumValueOf<T>(name)
+    } catch (e: IllegalArgumentException) {
+        null
+    }
+}

--- a/mimic-bukkit/src/main/kotlin/internal/Log.kt
+++ b/mimic-bukkit/src/main/kotlin/internal/Log.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of BukkitMimic.
- * Copyright (C) 2020 Osip Fatkullin
- * Copyright (C) 2020 EndlessCode Group and contributors
+ * Copyright (C) 2021 Osip Fatkullin
+ * Copyright (C) 2021 EndlessCode Group and contributors
  *
  * BukkitMimic is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -49,6 +49,13 @@ internal object Log {
      */
     fun w(message: String) {
         logger?.warning(message)
+    }
+
+    /**
+     * Writes warning exception to log.
+     */
+    fun w(throwable: Throwable) {
+        logger?.log(Level.WARNING, throwable.message, throwable)
     }
 
     /**

--- a/mimic-bukkit/src/main/kotlin/internal/Serializers.kt
+++ b/mimic-bukkit/src/main/kotlin/internal/Serializers.kt
@@ -28,6 +28,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import org.bukkit.NamespacedKey
 import org.bukkit.enchantments.Enchantment
+import org.bukkit.inventory.ItemFlag
 
 internal object EnchantmentSerializer : KSerializer<Enchantment> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Enchantment", PrimitiveKind.STRING)
@@ -43,4 +44,16 @@ internal object EnchantmentSerializer : KSerializer<Enchantment> {
     }
 
     override fun serialize(encoder: Encoder, value: Enchantment) = encoder.encodeString(value.key.toString())
+}
+
+internal object ItemFlagsSerializer : KSerializer<ItemFlag> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ItemFlag", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): ItemFlag {
+        val value = decoder.decodeString()
+        return enumValueOrNull<ItemFlag>(value.uppercase())
+            ?: throw SerializationException("$value is not a valid ItemFlag, must be one of ${ItemFlag.values()}")
+    }
+
+    override fun serialize(encoder: Encoder, value: ItemFlag) = encoder.encodeString(value.name)
 }

--- a/mimic-bukkit/src/main/kotlin/internal/Serializers.kt
+++ b/mimic-bukkit/src/main/kotlin/internal/Serializers.kt
@@ -1,0 +1,46 @@
+/*
+ * This file is part of BukkitMimic.
+ * Copyright (C) 2021 Osip Fatkullin
+ * Copyright (C) 2021 EndlessCode Group and contributors
+ *
+ * BukkitMimic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BukkitMimic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BukkitMimic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ru.endlesscode.mimic.internal
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import org.bukkit.NamespacedKey
+import org.bukkit.enchantments.Enchantment
+
+internal object EnchantmentSerializer : KSerializer<Enchantment> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Enchantment", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): Enchantment {
+        val value = decoder.decodeString()
+        val key = NamespacedKey.fromString(value.lowercase())
+            ?: throw SerializationException("$value is not a valid namespaced key, " +
+                    "only latin letters, digits and symbols /._- are allowed")
+        return Enchantment.getByKey(key)
+            ?: throw SerializationException("$value is not a valid key for enchantment, " +
+                    "must be one of: [${Enchantment.values().joinToString { it.key.toString() }}]")
+    }
+
+    override fun serialize(encoder: Encoder, value: Enchantment) = encoder.encodeString(value.key.toString())
+}

--- a/mimic-bukkit/src/main/kotlin/internal/Serializers.kt
+++ b/mimic-bukkit/src/main/kotlin/internal/Serializers.kt
@@ -35,9 +35,9 @@ internal object EnchantmentSerializer : KSerializer<Enchantment> {
 
     override fun deserialize(decoder: Decoder): Enchantment {
         val value = decoder.decodeString()
-        val key = NamespacedKey.fromString(value.lowercase())
-            ?: throw SerializationException("$value is not a valid namespaced key, " +
-                    "only latin letters, digits and symbols /._- are allowed")
+        val key = NamespacedKey.fromString(value.replace(" ", "_").lowercase())
+            ?: throw SerializationException("$value is not a valid key for enchantment, " +
+                    "only latin letters, digits and symbol _ are allowed")
         return Enchantment.getByKey(key)
             ?: throw SerializationException("$value is not a valid key for enchantment, " +
                     "must be one of: [${Enchantment.values().joinToString { it.key.toString() }}]")

--- a/mimic-bukkit/src/test/kotlin/impl/vanilla/ItemMetaPayloadTest.kt
+++ b/mimic-bukkit/src/test/kotlin/impl/vanilla/ItemMetaPayloadTest.kt
@@ -33,7 +33,7 @@ import kotlin.test.assertNull
 internal class ItemMetaPayloadTest {
 
     @ParameterizedTest
-    @ValueSource(strings = ["", "{}", "invalid:::", "display-name: 1"])
+    @ValueSource(strings = ["", "{}", "invalid:::", "name: 1"])
     fun `parse - empty or invalid object - should return null`(input: String) {
         // When
         val result = ItemMetaPayload.parse(input)
@@ -45,10 +45,10 @@ internal class ItemMetaPayloadTest {
     @Test
     fun `parse - flags in lowercase - should be case parsed`() {
         // When
-        val result = ItemMetaPayload.parse("item-flags: [hide_attributes, hide_dye]")
+        val result = ItemMetaPayload.parse("flags: [hide_attributes, hide_dye]")
 
         // Then
-        assertEquals(ItemMetaPayload(itemFlags = setOf(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_DYE)), result)
+        assertEquals(ItemMetaPayload(flags = setOf(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_DYE)), result)
     }
 
     @ParameterizedTest
@@ -66,26 +66,24 @@ internal class ItemMetaPayloadTest {
         @JvmStatic
         fun validData(): Stream<Arguments> = Stream.of(
             // Simple cases
-            arguments("{display-name: Name}", ItemMetaPayload(displayName = "Name")),
-            arguments("display-name=Name", ItemMetaPayload(displayName = "Name")),
+            arguments("{name: Name}", ItemMetaPayload(name = "Name")),
+            arguments("name=Name", ItemMetaPayload(name = "Name")),
             arguments(
                 """
-                    display-name = Display,
-                    localized-name = Localized, 
+                    name = Name,
                     lore = [Line1, Line2],
-                    is-unbreakable = true,
+                    unbreakable = true,
                     damage = 42,
                     custom-model-data = 24,
-                    item-flags = [HIDE_ATTRIBUTES, HIDE_DYE]
+                    flags = [HIDE_ATTRIBUTES, HIDE_DYE]
                 """.trimIndent(),
                 ItemMetaPayload(
-                    displayName = "Display",
-                    localizedName = "Localized",
+                    name = "Name",
                     lore = listOf("Line1", "Line2"),
                     isUnbreakable = true,
                     damage = 42,
                     customModelData = 24,
-                    itemFlags = setOf(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_DYE)
+                    flags = setOf(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_DYE)
                 )
             ),
             // Unknown fields

--- a/mimic-bukkit/src/test/kotlin/impl/vanilla/ItemMetaPayloadTest.kt
+++ b/mimic-bukkit/src/test/kotlin/impl/vanilla/ItemMetaPayloadTest.kt
@@ -33,8 +33,8 @@ import kotlin.test.assertNull
 internal class ItemMetaPayloadTest {
 
     @ParameterizedTest
-    @ValueSource(strings = ["", "{}"])
-    fun `parse - empty object - should return null`(input: String) {
+    @ValueSource(strings = ["", "{}", "invalid:::", "display-name: 1"])
+    fun `parse - empty or invalid object - should return null`(input: String) {
         // When
         val result = ItemMetaPayload.parse(input)
 

--- a/mimic-bukkit/src/test/kotlin/impl/vanilla/ItemMetaPayloadTest.kt
+++ b/mimic-bukkit/src/test/kotlin/impl/vanilla/ItemMetaPayloadTest.kt
@@ -1,0 +1,86 @@
+/*
+ * This file is part of BukkitMimic.
+ * Copyright (C) 2021 Osip Fatkullin
+ * Copyright (C) 2021 EndlessCode Group and contributors
+ *
+ * BukkitMimic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BukkitMimic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BukkitMimic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ru.endlesscode.mimic.impl.vanilla
+
+import org.bukkit.inventory.ItemFlag
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
+import java.util.stream.Stream
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class ItemMetaPayloadTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", "{}"])
+    fun `parse - empty object - should return null`(input: String) {
+        // When
+        val result = ItemMetaPayload.parse(input)
+
+        // Then
+        assertNull(result)
+    }
+
+    @ParameterizedTest
+    @MethodSource("validData")
+    fun `parse - valid input - should return configured object`(input: String, output: ItemMetaPayload) {
+        // When
+        val result = ItemMetaPayload.parse(input)
+
+        // Then
+        assertEquals(output, result)
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun validData(): Stream<Arguments> = Stream.of(
+            // Simple cases
+            arguments("{display-name: Name}", ItemMetaPayload(displayName = "Name")),
+            arguments("display-name=Name", ItemMetaPayload(displayName = "Name")),
+            arguments(
+                """
+                    display-name = Display,
+                    localized-name = Localized, 
+                    lore = [Line1, Line2],
+                    is-unbreakable = true,
+                    damage = 42,
+                    custom-model-data = 24,
+                    item-flags = [HIDE_ATTRIBUTES, HIDE_DYE]
+                """.trimIndent(),
+                ItemMetaPayload(
+                    displayName = "Display",
+                    localizedName = "Localized",
+                    lore = listOf("Line1", "Line2"),
+                    isUnbreakable = true,
+                    damage = 42,
+                    customModelData = 24,
+                    itemFlags = listOf(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_DYE)
+                )
+            ),
+            // Unknown fields
+            arguments("unknown: only", ItemMetaPayload()),
+            arguments("unknown: and, damage: 40", ItemMetaPayload(damage = 40)),
+        )
+    }
+}

--- a/mimic-bukkit/src/test/kotlin/impl/vanilla/ItemMetaPayloadTest.kt
+++ b/mimic-bukkit/src/test/kotlin/impl/vanilla/ItemMetaPayloadTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import java.util.stream.Stream
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
@@ -39,6 +40,15 @@ internal class ItemMetaPayloadTest {
 
         // Then
         assertNull(result)
+    }
+
+    @Test
+    fun `parse - flags in lowercase - should be case parsed`() {
+        // When
+        val result = ItemMetaPayload.parse("item-flags: [hide_attributes, hide_dye]")
+
+        // Then
+        assertEquals(ItemMetaPayload(itemFlags = setOf(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_DYE)), result)
     }
 
     @ParameterizedTest
@@ -75,7 +85,7 @@ internal class ItemMetaPayloadTest {
                     isUnbreakable = true,
                     damage = 42,
                     customModelData = 24,
-                    itemFlags = listOf(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_DYE)
+                    itemFlags = setOf(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_DYE)
                 )
             ),
             // Unknown fields


### PR DESCRIPTION
### API

- Add `MimicApiLevel` class to check current running Mimic API version:
  ```kotlin
  // Specify here the version required for APIs you use.
  if (!MimicApiLevel.checkApiLevel(MimicApiLevel.VERSION_0_6)) {
      println("At least Mimic 0.6 is required. Please download it from {link here}")
  }
  ```
- Add optional payload to `ItemsRegistry.getItem`. It may be used to customize items.

## Bukkit Plugin

- Add statistics about used items registries
- Add payload support to `MinecraftItemsRegistry`.