### PR TITLE
Add '/mimic config' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## [Unreleased]
 
+### Added command `/mimic config`
+
+Since now, it is possible to change Mimic config using commands in two ways:
+
+1. Using interactive config `/mimic config`.
+   Every option in the output is interactive, so you can change it just by mouse click.
+2. Change options by commands:
+   - `/mimic config level-system [value]` - set the specified level system as preferred for Mimic
+   - `/mimic config class-system [value]` - set the specified class system as preferred for Mimic
+   - `/mimic config inventory-provider [value]` - set the specified inventory provider as preferred for Mimic
+   - `/mimic config disabled-items-registries add [item-registry]` - disable the specified item registry for Mimic
+   - `/mimic config disabled-items-registries remove [item-registry]` - enable the specified item registry for Mimic
+
 ### API changes
 
 - Added tag `@since 0.8.0` to all new APIs

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -18,6 +18,7 @@ object misc {
     const val annotations = "org.jetbrains:annotations:23.0.0"
     const val serialization_hocon = "org.jetbrains.kotlinx:kotlinx-serialization-hocon:1.3.2"
     const val mockk = "io.mockk:mockk:1.12.3"
+    const val adventure = "net.kyori:adventure-platform-bukkit:4.3.1"
 }
 
 // Testing

--- a/mimic-bukkit/api/mimic-bukkit.api
+++ b/mimic-bukkit/api/mimic-bukkit.api
@@ -1,5 +1,6 @@
 public final class ru/endlesscode/mimic/MimicPlugin : org/bukkit/plugin/java/JavaPlugin {
 	public fun <init> ()V
+	public fun onDisable ()V
 	public fun onEnable ()V
 	public fun onLoad ()V
 }

--- a/mimic-bukkit/build.gradle.kts
+++ b/mimic-bukkit/build.gradle.kts
@@ -5,7 +5,7 @@ import ru.endlesscode.bukkitgradle.dependencies.spigotApi
 
 plugins {
     id("com.github.johnrengelman.shadow") version "7.1.0"
-    id("ru.endlesscode.bukkitgradle") version "0.10.0"
+    id("ru.endlesscode.bukkitgradle") version "0.10.1"
     kotlin("plugin.serialization")
 }
 
@@ -47,6 +47,7 @@ dependencies {
     implementation(acf.paper)
     implementation(misc.bstats)
     implementation(misc.serialization_hocon)
+    implementation(misc.adventure)
 
     compileOnly(rpgplugins.skillapi)
     compileOnly(rpgplugins.battlelevels)
@@ -79,6 +80,8 @@ tasks.shadowJar {
     relocate("kotlin", "$shadePackage.kotlin")
     relocate("org.bstats", "$shadePackage.bstats")
     relocate("com.typesafe.config", "$shadePackage.hocon")
+    relocate("net.kyori.adventure", "$shadePackage.adventure")
+    relocate("net.kyori.examination", "$shadePackage.examination")
 
     exclude("META-INF/*.kotlin_module")
     exclude("META-INF/maven/**")

--- a/mimic-bukkit/src/main/kotlin/MimicPlugin.kt
+++ b/mimic-bukkit/src/main/kotlin/MimicPlugin.kt
@@ -78,6 +78,7 @@ public class MimicPlugin : JavaPlugin() {
         pluginManager.registerEvents(ServicesRegistrationListener(servicesManager, mimic), this)
     }
 
+    @OptIn(ExperimentalMimicApi::class)
     private fun hookDefaultServices() {
         // Default systems
         Log.i(">>> Default systems")
@@ -145,7 +146,7 @@ public class MimicPlugin : JavaPlugin() {
     }
 
     @Suppress("SameParameterValue")
-    @OptIn(ExperimentalMimicApi::class)
+    @ExperimentalMimicApi
     private fun hookInventory(
         constructor: () -> BukkitPlayerInventory.Provider,
         priority: ServicePriority = Normal,

--- a/mimic-bukkit/src/main/kotlin/MimicPlugin.kt
+++ b/mimic-bukkit/src/main/kotlin/MimicPlugin.kt
@@ -20,6 +20,7 @@
 package ru.endlesscode.mimic
 
 import co.aikar.commands.PaperCommandManager
+import net.kyori.adventure.platform.bukkit.BukkitAudiences
 import org.bstats.bukkit.Metrics
 import org.bstats.charts.AdvancedPie
 import org.bstats.charts.SimplePie
@@ -62,6 +63,7 @@ public class MimicPlugin : JavaPlugin() {
 
     private val config: MimicConfig by lazy { MimicConfig(this) }
     private val mimic: Mimic by lazy { MimicImpl(servicesManager, config) }
+    private var audiences: BukkitAudiences? = null
 
     private inline val servicesManager get() = server.servicesManager
     private inline val pluginManager get() = server.pluginManager
@@ -73,6 +75,8 @@ public class MimicPlugin : JavaPlugin() {
     }
 
     override fun onEnable() {
+        audiences = BukkitAudiences.create(this)
+
         if (isReleased) initMetrics()
         registerCommands()
         pluginManager.registerEvents(ServicesRegistrationListener(servicesManager, mimic), this)
@@ -189,10 +193,16 @@ public class MimicPlugin : JavaPlugin() {
             "perm", "mimic.admin"
         )
 
-        manager.registerCommand(MainCommand(this, mimic))
+        manager.registerCommand(MainCommand(this, checkNotNull(audiences)))
+        manager.registerCommand(ConfigCommand(mimic, config, checkNotNull(audiences)))
         manager.registerCommand(LevelSystemSubcommand(mimic))
         manager.registerCommand(ClassSystemSubcommand(mimic))
         manager.registerCommand(InventorySubcommand(mimic))
         manager.registerCommand(ItemsSubcommand(mimic.getItemsRegistry()))
+    }
+
+    override fun onDisable() {
+        audiences?.close()
+        audiences = null
     }
 }

--- a/mimic-bukkit/src/main/kotlin/command/ConfigCommand.kt
+++ b/mimic-bukkit/src/main/kotlin/command/ConfigCommand.kt
@@ -1,0 +1,78 @@
+package ru.endlesscode.mimic.command
+
+import co.aikar.commands.AbstractCommandManager
+import co.aikar.commands.MimicCommand
+import co.aikar.commands.annotation.*
+import net.kyori.adventure.platform.bukkit.BukkitAudiences
+import org.bukkit.command.CommandSender
+import ru.endlesscode.mimic.ExperimentalMimicApi
+import ru.endlesscode.mimic.Mimic
+import ru.endlesscode.mimic.config.MimicConfig
+
+@OptIn(ExperimentalMimicApi::class)
+@CommandAlias("%command")
+@CommandPermission("%perm")
+@Subcommand("config")
+internal class ConfigCommand(
+    private val mimic: Mimic,
+    private val config: MimicConfig,
+    private val audiences: BukkitAudiences,
+) : MimicCommand() {
+
+    override fun afterRegister(manager: AbstractCommandManager) {
+        manager.commandCompletions.registerAsyncCompletion("level-system") {
+            mimic.getAllLevelSystemProviders().keys
+        }
+        manager.commandCompletions.registerAsyncCompletion("class-system") {
+            mimic.getAllClassSystemProviders().keys
+        }
+        manager.commandCompletions.registerAsyncCompletion("inventory-provider") {
+            mimic.getAllPlayerInventoryProviders().keys
+        }
+        manager.commandCompletions.registerAsyncCompletion("items-registry") {
+            mimic.getAllItemsRegistries().keys - MimicConfig.DEFAULT_ITEMS_REGISTRIES
+        }
+    }
+
+    @Default
+    @Description("Show config")
+    fun showConfig(sender: CommandSender) {
+        val message = buildConfigMessage(mimic, config)
+        audiences.sender(sender).sendMessage(message)
+    }
+
+    @Subcommand("level-system")
+    @CommandCompletion("@level-system")
+    fun setLevelSystem(sender: CommandSender, levelSystem: String) {
+        config.levelSystem = levelSystem
+        showConfig(sender)
+    }
+
+    @Subcommand("class-system")
+    @CommandCompletion("@class-system")
+    fun setClassSystem(sender: CommandSender, classSystem: String) {
+        config.classSystem = classSystem
+        showConfig(sender)
+    }
+
+    @Subcommand("inventory-provider")
+    @CommandCompletion("@inventory-provider")
+    fun setInventoryProvider(sender: CommandSender, inventoryProvider: String) {
+        config.inventoryProvider = inventoryProvider
+        showConfig(sender)
+    }
+
+    @Subcommand("disabled-items-registries add")
+    @CommandCompletion("@items-registry")
+    fun disableItemsRegistry(sender: CommandSender, inventoryProvider: String) {
+        config.disabledItemsRegistries += inventoryProvider
+        showConfig(sender)
+    }
+
+    @Subcommand("disabled-items-registries remove")
+    @CommandCompletion("@items-registry")
+    fun enableItemsRegistry(sender: CommandSender, inventoryProvider: String) {
+        config.disabledItemsRegistries -= inventoryProvider
+        showConfig(sender)
+    }
+}

--- a/mimic-bukkit/src/main/kotlin/command/ConfigMessage.kt
+++ b/mimic-bukkit/src/main/kotlin/command/ConfigMessage.kt
@@ -1,0 +1,81 @@
+package ru.endlesscode.mimic.command
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.event.HoverEvent
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.text.format.TextDecoration
+import ru.endlesscode.mimic.ExperimentalMimicApi
+import ru.endlesscode.mimic.Mimic
+import ru.endlesscode.mimic.MimicService
+import ru.endlesscode.mimic.config.MimicConfig
+import ru.endlesscode.mimic.config.StringConfigProperty
+import ru.endlesscode.mimic.internal.append
+import ru.endlesscode.mimic.internal.appendLine
+import ru.endlesscode.mimic.internal.buildTextComponent
+
+@OptIn(ExperimentalMimicApi::class)
+internal fun buildConfigMessage(mimic: Mimic): TextComponent = buildTextComponent {
+    appendSelectablePropertyConfig(
+        property = MimicConfig.LEVEL_SYSTEM,
+        selectedId = mimic.getLevelSystemProvider().id,
+        services = mimic.getAllLevelSystemProviders(),
+    )
+    appendSelectablePropertyConfig(
+        property = MimicConfig.CLASS_SYSTEM,
+        selectedId = mimic.getClassSystemProvider().id,
+        services = mimic.getAllClassSystemProviders(),
+    )
+    appendSelectablePropertyConfig(
+        property = MimicConfig.INVENTORY_PROVIDER,
+        selectedId = mimic.getPlayerInventoryProvider().id,
+        services = mimic.getAllPlayerInventoryProviders(),
+    )
+}
+
+private fun TextComponent.Builder.appendSelectablePropertyConfig(
+    property: StringConfigProperty,
+    selectedId: String,
+    services: Map<String, MimicService>,
+) {
+    appendLine()
+    appendComment(property.formattedTitle)
+    val availableOptions = (services - selectedId).values
+    if (availableOptions.isNotEmpty()) {
+        appendLine()
+        appendComment("Available options: ")
+        append(
+            availableOptions.toSelectableOptions(
+                hint = "Click to select this option",
+                command = "/mimic info",
+                color = NamedTextColor.GRAY,
+            )
+        )
+    }
+
+    append("\n${property.path}: ", NamedTextColor.GREEN)
+    append(selectedId)
+    appendLine()
+}
+
+private fun Collection<MimicService>.toSelectableOptions(
+    hint: String,
+    command: String,
+    color: TextColor? = null,
+) = mapIndexed { index, service ->
+    buildTextComponent {
+        color(color)
+        if (index != 0) append(", ")
+        appendClickable(service.id, hint, command)
+    }
+}
+
+private fun TextComponent.Builder.appendClickable(text: String, hint: String, command: String) {
+    append(text, TextDecoration.UNDERLINED)
+    hoverEvent(HoverEvent.showText(Component.text(hint)))
+    clickEvent(ClickEvent.runCommand(command))
+}
+
+private fun TextComponent.Builder.appendComment(comment: String) = append("# $comment", NamedTextColor.GRAY)

--- a/mimic-bukkit/src/main/kotlin/command/ConfigMessage.kt
+++ b/mimic-bukkit/src/main/kotlin/command/ConfigMessage.kt
@@ -10,14 +10,16 @@ import net.kyori.adventure.text.format.TextDecoration
 import ru.endlesscode.mimic.ExperimentalMimicApi
 import ru.endlesscode.mimic.Mimic
 import ru.endlesscode.mimic.MimicService
+import ru.endlesscode.mimic.config.ConfigProperty
 import ru.endlesscode.mimic.config.MimicConfig
 import ru.endlesscode.mimic.config.StringConfigProperty
+import ru.endlesscode.mimic.config.StringSetConfigProperty
 import ru.endlesscode.mimic.internal.append
 import ru.endlesscode.mimic.internal.appendLine
 import ru.endlesscode.mimic.internal.buildTextComponent
 
 @OptIn(ExperimentalMimicApi::class)
-internal fun buildConfigMessage(mimic: Mimic): TextComponent = buildTextComponent {
+internal fun buildConfigMessage(mimic: Mimic, config: MimicConfig): TextComponent = buildTextComponent {
     appendSelectablePropertyConfig(
         property = MimicConfig.LEVEL_SYSTEM,
         selectedId = mimic.getLevelSystemProvider().id,
@@ -33,49 +35,90 @@ internal fun buildConfigMessage(mimic: Mimic): TextComponent = buildTextComponen
         selectedId = mimic.getPlayerInventoryProvider().id,
         services = mimic.getAllPlayerInventoryProviders(),
     )
+    appendSetPropertyConfig(
+        property = MimicConfig.DISABLED_ITEMS_REGISTRIES,
+        values = config.disabledItemsRegistries,
+        services = mimic.getAllItemsRegistries(),
+    )
 }
 
 private fun TextComponent.Builder.appendSelectablePropertyConfig(
     property: StringConfigProperty,
     selectedId: String,
     services: Map<String, MimicService>,
-) {
-    appendLine()
-    appendComment(property.formattedTitle)
-    val availableOptions = (services - selectedId).values
+) = appendProperty(property) {
+    val availableOptions = services.keys - selectedId
     if (availableOptions.isNotEmpty()) {
         appendLine()
-        appendComment("Available options: ")
-        append(
-            availableOptions.toSelectableOptions(
-                hint = "Click to select this option",
-                command = "/mimic info",
-                color = NamedTextColor.GRAY,
-            )
+        appendComment("Options: ")
+        appendSelectableOptions(
+            availableOptions,
+            hint = "Click to select this option",
+            command = "/mimic info",
+            color = NamedTextColor.GRAY,
         )
     }
 
-    append("\n${property.path}: ", NamedTextColor.GREEN)
+    appendLine()
+    appendPropertyPath(property)
     append(selectedId)
+}
+
+private fun TextComponent.Builder.appendSetPropertyConfig(
+    property: StringSetConfigProperty,
+    values: Set<String>,
+    services: Map<String, MimicService>,
+) = appendProperty(property) {
+    val selectableIds = services.keys - values
+    appendLine()
+    appendComment("Options: ")
+    appendSelectableOptions(
+        selectableIds,
+        hint = "Click to add",
+        command = "/mimic info",
+        color = NamedTextColor.GRAY,
+    )
+
+    appendLine()
+    appendPropertyPath(property)
+    append("[")
+    appendSelectableOptions(
+        values,
+        hint = "Click to remove",
+        command = "/mimic info",
+    )
+    append("]")
+}
+
+private fun TextComponent.Builder.appendProperty(property: ConfigProperty<*>, body: TextComponent.Builder.() -> Unit) {
+    appendLine()
+    appendComment(property.formattedTitle)
+    body()
     appendLine()
 }
 
-private fun Collection<MimicService>.toSelectableOptions(
+private fun TextComponent.Builder.appendSelectableOptions(
+    options: Collection<String>,
     hint: String,
     command: String,
     color: TextColor? = null,
-) = mapIndexed { index, service ->
-    buildTextComponent {
-        color(color)
-        if (index != 0) append(", ")
-        appendClickable(service.id, hint, command)
+) = append(
+    options.mapIndexed { index, option ->
+        buildTextComponent {
+            color(color)
+            if (index != 0) append(", ")
+            appendClickable(option, hint, command)
+        }
     }
-}
+)
 
 private fun TextComponent.Builder.appendClickable(text: String, hint: String, command: String) {
     append(text, TextDecoration.UNDERLINED)
     hoverEvent(HoverEvent.showText(Component.text(hint)))
     clickEvent(ClickEvent.runCommand(command))
 }
+
+private fun TextComponent.Builder.appendPropertyPath(property: ConfigProperty<*>) =
+    append("${property.path}: ", NamedTextColor.GREEN)
 
 private fun TextComponent.Builder.appendComment(comment: String) = append("# $comment", NamedTextColor.GRAY)

--- a/mimic-bukkit/src/main/kotlin/command/MainCommand.kt
+++ b/mimic-bukkit/src/main/kotlin/command/MainCommand.kt
@@ -3,17 +3,20 @@ package ru.endlesscode.mimic.command
 import co.aikar.commands.CommandHelp
 import co.aikar.commands.MimicCommand
 import co.aikar.commands.annotation.*
+import net.kyori.adventure.platform.bukkit.BukkitAudiences
+import net.kyori.adventure.text.format.NamedTextColor
 import org.bukkit.command.CommandSender
 import org.bukkit.plugin.Plugin
-import ru.endlesscode.mimic.ExperimentalMimicApi
-import ru.endlesscode.mimic.Mimic
-import ru.endlesscode.mimic.MimicService
+import ru.endlesscode.mimic.internal.append
+import ru.endlesscode.mimic.internal.appendClickable
+import ru.endlesscode.mimic.internal.appendLine
+import ru.endlesscode.mimic.internal.buildTextComponent
 
 @CommandAlias("%command")
 @CommandPermission("%perm")
 internal class MainCommand(
     private val plugin: Plugin,
-    private val mimic: Mimic,
+    private val audiences: BukkitAudiences,
 ) : MimicCommand() {
 
     @HelpCommand
@@ -22,28 +25,25 @@ internal class MainCommand(
         help.showHelp()
     }
 
-    @OptIn(ExperimentalMimicApi::class)
     @Subcommand("info")
     @Description("Show info about Mimic and loaded services")
     fun info(sender: CommandSender) {
-        val levelSystems = mimic.getAllLevelSystemProviders()
-        val classSystems = mimic.getAllClassSystemProviders()
-        val playerInventories = mimic.getAllPlayerInventoryProviders()
-        val itemsRegistries = mimic.getAllItemsRegistries()
-
-        sender.send(
-            "&2${plugin.description.fullName}",
-            "&3Level Systems: &7${levelSystems.toMessage()}",
-            "&3Class Systems: &7${classSystems.toMessage()}",
-            "&3Inventory Providers: &7${playerInventories.toMessage()}",
-            "&3Items Registries: &7${itemsRegistries.toMessage()}",
-        )
+        val message = buildTextComponent {
+            appendLine(plugin.description.fullName, NamedTextColor.GREEN)
+            color(NamedTextColor.GRAY)
+            append("Use ")
+            append(createClickableCommand())
+            append(" to see or change configs")
+        }
+        audiences.sender(sender).sendMessage(message)
     }
-}
 
-private fun <ServiceT : MimicService> Map<String, ServiceT>.toMessage(): String {
-    return values.joinToString { service ->
-        val color = if (service.isEnabled) "&a" else "&c"
-        "$color${service.id}&7"
+    private fun createClickableCommand() = buildTextComponent {
+        color(NamedTextColor.YELLOW)
+        appendClickable(CONFIG_COMMAND, "Click to execute", CONFIG_COMMAND)
+    }
+
+    private companion object {
+        const val CONFIG_COMMAND = "/mimic config"
     }
 }

--- a/mimic-bukkit/src/main/kotlin/config/ConfigProperty.kt
+++ b/mimic-bukkit/src/main/kotlin/config/ConfigProperty.kt
@@ -33,6 +33,8 @@ internal sealed interface ConfigProperty<T : Any> {
     val comments: Array<String>
     val defaultValue: Any
 
+    val formattedTitle: String get() = "[$title]"
+
     fun ConfigurationSection.get(): T
     fun ConfigurationSection.set(value: T)
 }

--- a/mimic-bukkit/src/main/kotlin/config/ConfigProperty.kt
+++ b/mimic-bukkit/src/main/kotlin/config/ConfigProperty.kt
@@ -1,0 +1,50 @@
+package ru.endlesscode.mimic.config
+
+import org.bukkit.configuration.Configuration
+import org.bukkit.configuration.ConfigurationSection
+
+internal class StringSetConfigProperty(
+    override val path: String,
+    override val title: String,
+    override val comments: Array<String> = emptyArray(),
+) : ConfigProperty<Set<String>> {
+    override val defaultValue: List<String> = emptyList()
+    override fun ConfigurationSection.get(): Set<String> = getStringList(path).map { it.lowercase() }.toSet()
+    override fun ConfigurationSection.set(value: Set<String>) {
+        set(path, value.toList())
+    }
+}
+
+internal class StringConfigProperty(
+    override val path: String,
+    override val title: String,
+    override val comments: Array<String> = emptyArray(),
+) : ConfigProperty<String> {
+    override val defaultValue: String = ""
+    override fun ConfigurationSection.get(): String = getString(path).orEmpty().lowercase()
+    override fun ConfigurationSection.set(value: String) {
+        set(path, value)
+    }
+}
+
+internal sealed interface ConfigProperty<T : Any> {
+    val path: String
+    val title: String
+    val comments: Array<String>
+    val defaultValue: Any
+
+    fun ConfigurationSection.get(): T
+    fun ConfigurationSection.set(value: T)
+}
+
+internal fun Configuration.addDefault(property: ConfigProperty<*>) {
+    addDefault(property.path, property.defaultValue)
+}
+
+internal operator fun <T : Any> ConfigurationSection.get(property: ConfigProperty<T>): T {
+    return with(property) { get() }
+}
+
+internal operator fun <T : Any> ConfigurationSection.set(property: ConfigProperty<T>, value: T) {
+    with(property) { set(value) }
+}

--- a/mimic-bukkit/src/main/kotlin/config/ConfigurationDelegate.kt
+++ b/mimic-bukkit/src/main/kotlin/config/ConfigurationDelegate.kt
@@ -1,0 +1,19 @@
+package ru.endlesscode.mimic.config
+
+import org.bukkit.configuration.Configuration
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+internal fun <T : Any> Configuration.property(configProperty: ConfigProperty<T>): ReadWriteProperty<MimicConfig, T> {
+    return object : ReadWriteProperty<MimicConfig, T> {
+        override fun getValue(thisRef: MimicConfig, property: KProperty<*>): T = get(configProperty)
+
+        override fun setValue(thisRef: MimicConfig, property: KProperty<*>, value: T) {
+            val valueChanged = get(configProperty) != value
+            if (valueChanged) {
+                set(configProperty, value)
+                thisRef.save()
+            }
+        }
+    }
+}

--- a/mimic-bukkit/src/main/kotlin/config/MimicConfig.kt
+++ b/mimic-bukkit/src/main/kotlin/config/MimicConfig.kt
@@ -16,14 +16,10 @@ internal class MimicConfig(
     private val configuration: FileConfiguration = YamlConfiguration(),
 ) {
 
-    var levelSystem: String = ""
-        private set
-    var classSystem: String = ""
-        private set
-    var inventoryProvider: String = ""
-        private set
-    var disabledItemsRegistries: Set<String> = emptySet()
-        private set
+    var levelSystem: String by configuration.property(LEVEL_SYSTEM)
+    var classSystem: String by configuration.property(CLASS_SYSTEM)
+    var inventoryProvider: String by configuration.property(INVENTORY_PROVIDER)
+    var disabledItemsRegistries: Set<String> by configuration.property(DISABLED_ITEMS_REGISTRIES)
 
     constructor(plugin: Plugin) : this(plugin.toString(), File(plugin.dataFolder, "config.yml"))
 
@@ -47,28 +43,24 @@ internal class MimicConfig(
                 file.createNewFile()
             }
             configuration.load(file)
-            readConfigValues()
+            validateConfigValues()
         } catch (e: Throwable) {
             Log.w(e, "Failed to load config.")
         }
         save()
     }
 
-    private fun readConfigValues() {
-        levelSystem = configuration[LEVEL_SYSTEM]
-        classSystem = configuration[CLASS_SYSTEM]
-        inventoryProvider = configuration[INVENTORY_PROVIDER]
+    private fun validateConfigValues() {
+        val configuredDisabledItemsRegistries = disabledItemsRegistries
+        disabledItemsRegistries = configuredDisabledItemsRegistries - DEFAULT_ITEMS_REGISTRIES
 
-        val disabledItemsRegistries = configuration[DISABLED_ITEMS_REGISTRIES]
-        this.disabledItemsRegistries = disabledItemsRegistries - DEFAULT_ITEMS_REGISTRIES
-
-        val notDisabledRegistries = disabledItemsRegistries - this.disabledItemsRegistries
+        val notDisabledRegistries = configuredDisabledItemsRegistries - disabledItemsRegistries
         if (notDisabledRegistries.isNotEmpty()) {
             Log.w("Config: Items registries $notDisabledRegistries can not be disabled. It will be removed from config.")
         }
     }
 
-    private fun save() {
+    fun save() {
         try {
             configuration.applyDefaults()
             configuration.addComments()

--- a/mimic-bukkit/src/main/kotlin/config/MimicConfig.kt
+++ b/mimic-bukkit/src/main/kotlin/config/MimicConfig.kt
@@ -76,7 +76,7 @@ internal class MimicConfig(
             setComments(
                 path = property.path,
                 *lineBreak,
-                "[${property.title}]",
+                property.formattedTitle,
                 *property.comments,
             )
         }

--- a/mimic-bukkit/src/main/kotlin/internal/TextComponent.kt
+++ b/mimic-bukkit/src/main/kotlin/internal/TextComponent.kt
@@ -1,0 +1,28 @@
+package ru.endlesscode.mimic.internal
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.format.TextColor
+import net.kyori.adventure.text.format.TextDecoration
+
+internal fun buildTextComponent(builder: TextComponent.Builder.() -> Unit): TextComponent = Component.text(builder)
+
+internal fun TextComponent.Builder.appendLine(
+    text: String,
+    color: TextColor? = null,
+    vararg decorations: TextDecoration,
+): TextComponent.Builder = append(text, color, *decorations).appendLine()
+
+internal fun TextComponent.Builder.appendLine(): TextComponent.Builder = append("\n")
+
+internal fun TextComponent.Builder.append(
+    text: String,
+    color: TextColor? = null,
+    vararg decorations: TextDecoration,
+): TextComponent.Builder {
+    return append(Component.text(text, color, *decorations))
+}
+
+internal fun TextComponent.Builder.append(text: String, vararg decorations: TextDecoration): TextComponent.Builder {
+    return append(Component.text(text, null, *decorations))
+}

--- a/mimic-bukkit/src/main/kotlin/internal/TextComponent.kt
+++ b/mimic-bukkit/src/main/kotlin/internal/TextComponent.kt
@@ -2,6 +2,8 @@ package ru.endlesscode.mimic.internal
 
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.event.HoverEvent
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
 
@@ -25,4 +27,10 @@ internal fun TextComponent.Builder.append(
 
 internal fun TextComponent.Builder.append(text: String, vararg decorations: TextDecoration): TextComponent.Builder {
     return append(Component.text(text, null, *decorations))
+}
+
+internal fun TextComponent.Builder.appendClickable(text: String, hint: String, command: String) {
+    append(text, TextDecoration.UNDERLINED)
+    hoverEvent(HoverEvent.showText(Component.text(hint)))
+    clickEvent(ClickEvent.runCommand(command))
 }


### PR DESCRIPTION
Since now, it is possible to change Mimic config using commands in two ways:

1. Using interactive config `/mimic config`.
   Every option in the output is interactive, so you can change it just by mouse click.
2. Change options by commands:
   - `/mimic config level-system [value]` - set the specified level system as preferred for Mimic
   - `/mimic config class-system [value]` - set the specified class system as preferred for Mimic
   - `/mimic config inventory-provider [value]` - set the specified inventory provider as preferred for Mimic
   - `/mimic config disabled-items-registries add [item-registry]` - disable the specified item registry for Mimic
   - `/mimic config disabled-items-registries remove [item-registry]` - enable the specified item registry for Mimic
